### PR TITLE
docs: Update url at README due to name change

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 <br>
 
-## [3. 주요 기능 및 페이지 구성](https://github.com/hjinn0813/nimbus/wiki/Step-01.-%EA%B8%B0%ED%9A%8D-%EB%B0%8F-%EC%B4%88%EA%B8%B0-%EC%84%B8%ED%8C%85)
+## [3. 주요 기능 및 페이지 구성](https://github.com/yjinn0813/nimbus/wiki/Step-01.-%EA%B8%B0%ED%9A%8D-%EB%B0%8F-%EC%B4%88%EA%B8%B0-%EC%84%B8%ED%8C%85)
 
 <br>
 
@@ -53,7 +53,7 @@
 
 <br>
 
-## [5. 개발 기록 아카이빙](https://github.com/hjinn0813/nimbus/wiki/Step-01.-%EA%B8%B0%ED%9A%8D-%EB%B0%8F-%EC%B4%88%EA%B8%B0-%EC%84%B8%ED%8C%85)
+## [5. 개발 기록 아카이빙](https://github.com/yjinn0813/nimbus/wiki/Step-01.-%EA%B8%B0%ED%9A%8D-%EB%B0%8F-%EC%B4%88%EA%B8%B0-%EC%84%B8%ED%8C%85)
 
 <br>
 


### PR DESCRIPTION
## Overview
This PR updates my contributor information and Wiki links in the README. As I have recently changed my GitHub username, I am updating these links to ensure they redirect correctly to my current profile and the project's documentation.

## Changes
- Updated GitHub Wiki Links: Updated the URLs to point to the new username to prevent 404 errors and maintain access to the project's documentation.

<br>