### PR TITLE
chore: add Vercel rewrite configuration for SPA routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,5 +108,6 @@
  ┣ 📜postcss.config.cjs
  ┣ 📜tailwind.config.cjs
  ┣ 📜tsconfig.json
+ ┣ 📜vercel.json
  ┗ 📜vite.config.ts
 ```

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/" }
+  ]
+}


### PR DESCRIPTION
## Overview
This PR configures Vercel to properly support client-side routing in the SPA.
Without this setup, direct navigation to undefined routes resulted in Vercel’s default 404 page instead of the custom NotFound page. The rewrite rule ensures all routes are handled by the React application.

## Changes
- Add `vercel.json` with rewrite rules
- Route all incoming requests to `index.html`
- Enable proper rendering of custom NotFound page for undefined routes

<br>