### PR TITLE
chore: replace deprecated TypeScript compiler options

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,21 +1,34 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    /* Language and Environment */
+    "target": "ES2020",
     "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "strict": false,
-    "forceConsistentCasingInFileNames": true,
-    "noFallthroughCasesInSwitch": true,
+
+    /* React */
+    "jsx": "react-jsx",
+    "types": ["vite/client"],
+
+    /* Module */
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
+
+    /* Type Checking */
+    "strict": false,
+    "noImplicitAny": false,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+
+    /* Interop */
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+
+    /* Project Structure */
+    "allowJs": true,
+    "checkJs": false,
     "noEmit": true,
-    "jsx": "react-jsx",
-    "types": ["vite/client"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Overview

Updated deprecated TypeScript compiler options in `tsconfig.json` to align with the latest TypeScript recommendations and improve future compatibility.

## Changes

* Replaced deprecated compiler options that will be removed in TypeScript 7.0
* Updated TypeScript configuration to use modern module resolution settings
* Removed deprecation warnings during type checking
* Improved compiler options to better match the current Vite environment

<br>