### PR TITLE
ci: adjust cron schedule for weekly security audit

### DIFF
--- a/.github/workflows/dependency-monitor.yml
+++ b/.github/workflows/dependency-monitor.yml
@@ -2,7 +2,7 @@ name: Dependency Monitor for nimbus
 
 on:
   schedule: 
-    - cron: '0 4 * * 1' #KST 월요일 13:00
+    - cron: '0 22 * * 0' #KST 월요일 07:00
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Overview
Rescheduled the cron trigger for the weekly npm dependency vulnerability scan. By moving the trigger time out of peak hours, this change ensures that the security reports are generated and delivered via Discord without standing in long runner queues.

## Changes
- **Workflow Shift**: Refactored the cron schedule from Monday 13:00 KST (04:00 UTC) to Monday 07:00 KST (22:00 UTC Sunday).
- **Efficiency**: Restructured the timing sequence to guarantee the audit results are available right at the start of the morning.

<br>